### PR TITLE
api: ignore instance not found when removing instance

### DIFF
--- a/setupapihost/host.c
+++ b/setupapihost/host.c
@@ -72,6 +72,8 @@ VOID __stdcall RemoveInstance(HWND hwnd, HINSTANCE hinst, LPSTR lpszCmdLine, int
     if (!SetupDiOpenDeviceInfoW(DevInfo, InstanceId, NULL, DIOD_INHERIT_CLASSDRVS, &DevInfoData))
     {
         LastError = GetLastError();
+        if (LastError == ERROR_PATH_NOT_FOUND)
+            LastError = ERROR_SUCCESS;
         goto cleanupDevInfo;
     }
     SP_REMOVEDEVICE_PARAMS RemoveDeviceParams = { .ClassInstallHeader = { .cbSize = sizeof(SP_CLASSINSTALL_HEADER),


### PR DESCRIPTION
Should SetupAPI report ERROR_PATH_NOT_FOUND on attempt to remove the adapter instance, the adapter is already gone and we already have what we wanted.

Reference: https://lists.zx2c4.com/pipermail/wireguard/2025-February/008762.html