### PR TITLE
0.13: Fix CGNAT regression, remove spin locks

### DIFF
--- a/driver/device.c
+++ b/driver/device.c
@@ -148,7 +148,7 @@ MagicConnectorIPV4NAT(_Inout_ WG_PEER *Peer, _Inout_ IPV4HDR *Hdr, _Inout_ UINT1
      * tier on start. This will help us figure out the first octet that we
      * ought not NAT on the receive side.
      */
-    if (Hdr->Protocol == IPPROTO_ICMP)
+    if (CurrentPeerFirstOctet == 0 && Hdr->Protocol == IPPROTO_ICMP)
     {
         __iso_volatile_store8(&Peer->PeerFirstOctet, FirstOctet);
     }

--- a/driver/device.c
+++ b/driver/device.c
@@ -139,9 +139,19 @@ MagicConnectorIPV4NAT(_Inout_ WG_PEER *Peer, _Inout_ IPV4HDR *Hdr, _Inout_ UINT1
 
     *OldVal = (UINT16)(Hdr->Saddr & 0x0000FFFF);
 
-    KIRQL Irql = ExAcquireSpinLockShared(&Peer->EndpointLock);
-    UINT8 CurrentENatIndex = Peer->ENatIndex, CurrentONatIndex = Peer->ONatIndex;
-    ExReleaseSpinLockShared(&Peer->EndpointLock, Irql);
+    UINT8 CurrentPeerFirstOctet = __iso_volatile_load8(&Peer->PeerFirstOctet);
+    UINT8 CurrentENatIndex = __iso_volatile_load8(&Peer->ENatIndex);
+    UINT8 CurrentONatIndex = __iso_volatile_load8(&Peer->ONatIndex);
+
+    /*
+     * Capture the first outbound ping that happens from connector to access
+     * tier on start. This will help us figure out the first octet that we
+     * ought not NAT on the receive side.
+     */
+    if (Hdr->Protocol == IPPROTO_ICMP)
+    {
+        __iso_volatile_store8(&Peer->PeerFirstOctet, FirstOctet);
+    }
 
     if (FirstOctet == 10)
     {

--- a/driver/peer.h
+++ b/driver/peer.h
@@ -72,6 +72,19 @@ typedef struct _WG_PEER
     LIST_ENTRY PeerList;
     LIST_ENTRY AllowedIpsList;
     UINT64 InternalId;
+
+    /*
+     * PeerFirstOctet represents the first octet for the connector side IP
+     * address. This allows us to keep track of the NAT index to exclude from
+     * out NAT mapping logic.
+     */
+    UINT8 PeerFirstOctet;
+
+    /*
+     * ENatIndex and ONatIndex represent the NAT index when we're doing NAT on
+     * inbound traffic from access tier to connector. These indices are always
+     * contiguous.
+     */
     UINT8 ENatIndex, ONatIndex;
 } WG_PEER;
 

--- a/driver/peer.h
+++ b/driver/peer.h
@@ -72,19 +72,7 @@ typedef struct _WG_PEER
     LIST_ENTRY PeerList;
     LIST_ENTRY AllowedIpsList;
     UINT64 InternalId;
-
-    /*
-     * PeerFirstOctet represents the first octet for the connector side IP
-     * address. This allows us to keep track of the NAT index to exclude from
-     * out NAT mapping logic.
-     */
     UINT8 PeerFirstOctet;
-
-    /*
-     * ENatIndex and ONatIndex represent the NAT index when we're doing NAT on
-     * inbound traffic from access tier to connector. These indices are always
-     * contiguous.
-     */
     UINT8 ENatIndex, ONatIndex;
 } WG_PEER;
 

--- a/driver/receive.c
+++ b/driver/receive.c
@@ -377,6 +377,8 @@ DemagicConnectorIPV4NAT(_Inout_ WG_PEER *Peer, _Inout_ IPV4HDR *Hdr, _Inout_ UIN
      * connector RFC 1918 networks. The basic flow here is:
      *
      * Case 0: Address is already RFC 1918 or public IP, return as-is.
+     *         Also, if the first octet is equal to our connector peer IP, then
+     *         we ought skip NAT.
      *
      * Case 1: If natIndex % 2 == 0 => First octet is 10.
      *
@@ -414,33 +416,29 @@ DemagicConnectorIPV4NAT(_Inout_ WG_PEER *Peer, _Inout_ IPV4HDR *Hdr, _Inout_ UIN
     UINT8 NatIndex = (Daddr4 >> 24) & 0xFFFFFFFF;
     UINT8 SecondOctet = (Daddr4 >> 16) & 0xFFFFFFFF;
     UINT32 NatIndexBitMask = 0x00FFFFFF;
+    UINT8 CurrentPeerFirstOctet = __iso_volatile_load8(&Peer->PeerFirstOctet);
     
     *OldVal = (UINT16)(Hdr->Daddr & 0x0000FFFF);
 
     // Case 0
-    if (NatIndex > MAX_CONNECTOR_NAT_INDEX)
+    if (NatIndex > MAX_CONNECTOR_NAT_INDEX || NatIndex == CurrentPeerFirstOctet)
     {
         return;
     }
 
-    KIRQL Irql = ExAcquireSpinLockShared(&Peer->EndpointLock);
-    UINT8 CurrentENatIndex = Peer->ENatIndex, CurrentONatIndex = Peer->ONatIndex;
-    ExReleaseSpinLockShared(&Peer->EndpointLock, Irql);
+    UINT8 CurrentENatIndex = __iso_volatile_load8(&Peer->ENatIndex);
+    UINT8 CurrentONatIndex = __iso_volatile_load8(&Peer->ONatIndex);
 
     // Keep track of NAT index so we can do an easy lookup when sending back.
     if (CurrentENatIndex == 0 && NatIndex % 2 == 0)
     {
-        Irql = ExAcquireSpinLockExclusive(&Peer->EndpointLock);
-        Peer->ENatIndex = NatIndex;
-        Peer->ONatIndex = NatIndex + 1;
-        ExReleaseSpinLockExclusive(&Peer->EndpointLock, Irql);
+        __iso_volatile_store8(&Peer->ENatIndex, NatIndex);
+        __iso_volatile_store8(&Peer->ONatIndex, NatIndex + 1);
     }
     else if (CurrentONatIndex == 0 && NatIndex % 2 != 0)
     {
-        Irql = ExAcquireSpinLockExclusive(&Peer->EndpointLock);
-        Peer->ONatIndex = NatIndex;
-        Peer->ENatIndex = NatIndex - 1;
-        ExReleaseSpinLockExclusive(&Peer->EndpointLock, Irql);
+        __iso_volatile_store8(&Peer->ONatIndex, NatIndex);
+        __iso_volatile_store8(&Peer->ENatIndex, NatIndex - 1);
     }
 
     // Case 1: Set first octet to 10.

--- a/wireguard-nt.props
+++ b/wireguard-nt.props
@@ -78,7 +78,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <WireGuardVersionMaj>0</WireGuardVersionMaj>
-    <WireGuardVersionMin>12</WireGuardVersionMin>
+    <WireGuardVersionMin>13</WireGuardVersionMin>
     <WireGuardVersionRel>0</WireGuardVersionRel>
 
     <!-- Used for versioning, must be n.n[.n[.n]]. -->


### PR DESCRIPTION
WIP although current testing looks OK.

The previous PR is in review w/ MS as 0.12. This PR is in review w/ MS as 0.13 and is the target RC for this month.

0.13 fixes a regression where the translation was unconditional. Part of the reason the previous driver code only went up to 99 as the maximum index for translation was because it would break our CGNAT peers using a 100 as the first octet value by default, which would effectively break pings, DNS lookups, and (now) GRE tunneling.

This code addresses this by adding a new variable to track the first outbound ping from the `wg1` interface. Once we know what the source address of connector is, we can tell what needs NAT translation in the receive path.

As an aside, this change also addresses a performance issue where spin locks were used in a performance critical path. It now prefers the use of `__iso_volatile_*` routines which are [atomic under VS2019](https://devblogs.microsoft.com/cppblog/msvc-backend-updates-in-visual-studio-2019-versions-16-3-and-16-4/) backend semantics.

There is still a potential race under the read-**modify**-write case but I don't think it'll matter here in practice if two multi-threaded modifications happen at the same time _for GRE_. For NAT, I'm somewhat skeptical that this code is 100% correct. It seems like there's a possible race if someone decides to run a ping on a backend resource while connector starts. Of course, the only reason I even have this code is to support the case where someone may modify the default CGNAT ranges which may be a fool's errand, anyway... so looking for some input on that part.